### PR TITLE
riffxtract - block type decode to use full 0-255 character range

### DIFF
--- a/riffxtract
+++ b/riffxtract
@@ -239,10 +239,10 @@ def parse_riff(fileContent, offset):
         block_type = struct.unpack("cccc", fileContent[index:(index+4)])
         bt = []
         for c in range(0,4):
-            if (block_type[c].decode('ascii') > '\0' and
-                block_type[c].decode('ascii') >= ' ' and
-                block_type[c].decode('ascii') <= 'z'):
-                bt.append(block_type[c].decode('ascii'))
+            if (block_type[c].decode('latin1') > '\0' and
+                block_type[c].decode('latin1') >= ' ' and
+                block_type[c].decode('latin1') <= 'z'):
+                bt.append(block_type[c].decode('latin1'))
             else:
                 bt.append('_')
         block_type = ('%c%c%c%c'%(bt[0], bt[1], bt[2], bt[3]))


### PR DESCRIPTION
On my system some test files crash at line 242 with errors like this:

```
Traceback (most recent call last):
  File "../riffxtract", line 347, in <module>
    parse_riff(fileContent, rifx_offset)
  File "../riffxtract", line 242, in parse_riff
    if (block_type[c].decode('ascii') > '\0' and
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe5 in position 0: ordinal not in range(128)
```

Python's "ascii" supports only chars in range 0-127.  Using "latin1" codepage it can support the full 0-255 byte range.  Since these upper chars are replaced with `_` anyway, the fix seems OK to me.